### PR TITLE
    Fixing issue13: setup.py does not fallback to using distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python
-from setuptools import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 setup(
     name='contextlib2',


### PR DESCRIPTION
    Added falling back to distutils.core
    Tested install on a machine with and without setuptools

This fixes jazzband/contextlib2#13