### PR TITLE
dropped python 2.6 support, updated travis config, pep8 compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 matrix:
   include:
-  - python: 2.6
-    env: TOXENV=py26
   - python: 2.7
     env: TOXENV=py27
   - python: 3.4
@@ -11,14 +9,13 @@ matrix:
     env: TOXENV=py35
   - python: 3.6
     env: TOXENV=py36
-  - python: nightly
+  - python: 3.7
     env: TOXENV=py37
+    dist: xenial # required for Python >= 3.7
   - python: pypy
     env: TOXENV=pypy
-# Travis CI hasn't updated to PyPy3 5.5+ yet, so still has the exception
-# chaining compatibility bug that breaks the contextlib2 tests
-#  - python: pypy3
-#    env: TOXENV=pypy3
+  - python: pypy3
+    env: TOXENV=pypy3
 install: pip install tox coveralls && tox --notest
 script: tox
 after_success: coveralls

--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,6 @@ You can test against multiple versions of Python with
 
 Versions currently tested in both tox and Travis CI are:
 
-* CPython 2.6
 * CPython 2.7
 * CPython 3.4
 * CPython 3.5

--- a/README.rst
+++ b/README.rst
@@ -44,13 +44,6 @@ Versions currently tested in both tox and Travis CI are:
 * CPython 3.4
 * CPython 3.5
 * CPython 3.6
-* CPython 3.7 (CPython development branch)
+* CPython 3.7
 * PyPy
-
-Versions currently tested only in tox are:
-
 * PyPy3
-
-This is due to an exception chaining compatibility bug that was fixed in
-the PyPy3 5.5 alpha release, while the version on Travis CI (as of April 2017)
-is still the older PyPy3 2.4.0 release.

--- a/contextlib2.py
+++ b/contextlib2.py
@@ -11,8 +11,9 @@ __all__ = ["contextmanager", "closing", "ContextDecorator", "ExitStack",
 # Backwards compatibility
 __all__ += ["ContextStack"]
 
+
 class ContextDecorator(object):
-    "A base class or mixin that enables context managers to work as decorators."
+    """A base class or mixin that enables context managers to work as decorators."""
 
     def refresh_cm(self):
         """Returns the context manager used to actually wrap the call to the
@@ -176,8 +177,10 @@ class closing(object):
     """
     def __init__(self, thing):
         self.thing = thing
+
     def __enter__(self):
         return self.thing
+
     def __exit__(self, *exc_info):
         self.thing.close()
 
@@ -289,7 +292,7 @@ else:
     # but use exec to avoid SyntaxError in Python 3
     def _reraise_with_existing_context(exc_details):
         exc_type, exc_value, exc_tb = exc_details
-        exec ("raise exc_type, exc_value, exc_tb")
+        exec("raise exc_type, exc_value, exc_tb")
 
 # Handle old-style classes if they exist
 try:
@@ -302,8 +305,9 @@ else:
     def _get_type(obj):
         obj_type = type(obj)
         if obj_type is InstanceType:
-            return obj.__class__ # Old-style class
-        return obj_type # New-style class
+            return obj.__class__  # Old-style class
+        return obj_type  # New-style class
+
 
 # Inspired by discussions on http://bugs.python.org/issue13585
 class ExitStack(object):
@@ -416,6 +420,7 @@ class ExitStack(object):
         if pending_raise:
             _reraise_with_existing_context(exc_details)
         return received_exc and suppressed_exc
+
 
 # Preserve backwards compatibility
 class ContextStack(ExitStack):

--- a/setup.py
+++ b/setup.py
@@ -19,12 +19,12 @@ setup(
         'License :: OSI Approved :: Python Software Foundation License',
         # These are the Python versions tested, it may work on others
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
 )

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ except ImportError:
 setup(
     name='contextlib2',
     version=open('VERSION.txt').read().strip(),
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     py_modules=['contextlib2'],
     license='PSF License',
     description='Backports and enhancements for the contextlib module',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,34,35,36,37,py,py3}
+envlist = py{27,34,35,36,37,py,py3}
 skip_missing_interpreters = True
 
 [testenv]
@@ -9,6 +9,5 @@ commands =
     coverage report
 deps =
     coverage
-    py26: unittest2
     py27: unittest2
     pypy: unittest2


### PR DESCRIPTION
Dropped support for Python 2.6 as it reached EOL in 2013 and not supported by both tox and setuptools anymore
Enabled back Travis CI testing in pypy3 env, using stable python 3.7
Updated setup.py according to all the changes
Fixed several formatting issues to better comply with PEP8