### PR TITLE
Add basic pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+repos:
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-check-blanket-noqa
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.0.1
+    hooks:
+      - id: check-merge-conflict
+      - id: check-yaml
+
+ci:
+  autoupdate_schedule: quarterly


### PR DESCRIPTION
More can be added as required (see https://pre-commit.com/hooks.html), but this adds a basic pre-commit config file to stop the check erroring PRs (e.g. https://github.com/jazzband/contextlib2/pull/48): 

![image](https://user-images.githubusercontent.com/1324225/141189698-22b42094-1e9a-46c5-892c-4609f004a519.png)

