### PR TITLE
Update supported versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,13 +8,16 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 'pypy-3.8']
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 'pypy-3.10']
+
+    # Check https://github.com/actions/action-versions/tree/main/config/actions
+    # for latest versions if the standard actions start emitting warnings
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -24,7 +27,7 @@ jobs:
         echo "::set-output name=dir::$(pip cache dir)"
 
     - name: Cache
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ${{ steps.pip-cache.outputs.dir }}
         key:

--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,16 @@ try:
 except ImportError:
     from distutils.core import setup
 
+# Note: The minimum Python version requirement is set on the basis of
+#       "if it's not tested, it's broken".
+#       Specifically, if a Python version is no longer available for testing
+#       in CI, then the minimum supported Python version will be increased.
+#       That way there's no risk of a release that breaks older Python versions.
+
 setup(
     name='contextlib2',
     version=open('VERSION.txt').read().strip(),
-    python_requires='>=3.6',
+    python_requires='>=3.7',
     packages=['contextlib2'],
     include_package_data=True,
     license='PSF License',
@@ -23,11 +29,12 @@ setup(
         # These are the Python versions tested, it may work on others
         # It definitely won't work on versions without native async support
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
     ],
 
 )

--- a/test/test_contextlib.py
+++ b/test/test_contextlib.py
@@ -494,7 +494,8 @@ class TestContextDecorator(unittest.TestCase):
             def __exit__(self, *exc):
                 pass
 
-        with self.assertRaises(AttributeError):
+        # 3.11+ raises TypeError, older versions raise AttributeError
+        with self.assertRaises((AttributeError, TypeError)):
             with mycontext():
                 pass
 
@@ -506,7 +507,8 @@ class TestContextDecorator(unittest.TestCase):
             def __uxit__(self, *exc):
                 pass
 
-        with self.assertRaises(AttributeError):
+        # 3.11+ raises TypeError, older versions raise AttributeError
+        with self.assertRaises((AttributeError, TypeError)):
             with mycontext():
                 pass
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 # No Python 3.6 available on current generation GitHub test runners
-envlist = py{37,38,39,3.10,py3}
+envlist = py{37,38,39,3.10,3.11,3.12,py3}
 skip_missing_interpreters = True
 
 [testenv]
@@ -21,4 +21,6 @@ python =
     3.8: py38
     3.9: py39
     3.10: py3.10
+    3.11: py3.11
+    3.12: py3.12
     pypy-3.8: pypy3


### PR DESCRIPTION
* Add Python 3.11 and 3.12 to CI (adjusting affected test cases)
* Add Python 3.11 and 3.12 to package metadata
* Drop Python 3.6 from package metadata

Note: typechecking is still disabled in CI for now

Closes #56 