### PR TITLE
Fix typechecking with recent mypy releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12, 'pypy-3.10']
+        python-version: [3.8, 3.9, '3.10', 3.11, 3.12, 'pypy-3.10']
 
     # Check https://github.com/actions/action-versions/tree/main/config/actions
     # for latest versions if the standard actions start emitting warnings

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include *.py *.cfg *.txt *.rst *.md *.ini MANIFEST.in
+include *.py *.cfg *.txt *.rst *.md *.ini MANIFEST.in dev/mypy.allowlist
 recursive-include contextlib2 *.py *.pyi py.typed
 recursive-include docs *.rst *.py make.bat Makefile
 recursive-include test *.py

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -1,6 +1,28 @@
 Release History
 ---------------
 
+24.6.0 (2024-06-??)
+^^^^^^^^^^^^^^^^^^^
+
+* Due to the use of positional-only argument syntax, the minimum supported
+  Python version is now Python 3.8.
+* Update ``mypy stubtest`` to work with recent mypy versions (mypy 1.8.0 tested)
+  (`#54 <https://github.com/jazzband/contextlib2/issues/54>`__)
+* The ``dev/mypy.allowlist`` file needed for the ``mypy stubtest`` step in the
+  ``tox`` test configuration is now included in the published sdist
+  (`#53 <https://github.com/jazzband/contextlib2/issues/53>`__)
+* Type hints have been updated to include ``nullcontext`` (3.10 API added in
+  21.6.0) (`#41 <https://github.com/jazzband/contextlib2/issues/41>`__)
+* Test suite updated to pass on Python 3.11 and 3.12 (21.6.0 works on these
+  versions, the test suite just failed due to no longer valid assumptions)
+  (`#51 <https://github.com/jazzband/contextlib2/issues/51>`__)
+* Updates to the default compatibility testing matrix:
+
+  * Added: CPython 3.11, CPython 3.12
+  * Dropped: CPython 3.6, CPython 3.7
+
+python -m mypy.stubtest --allowlist dev/mypy.allowlist contextlib2
+
 21.6.0 (2021-06-27)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/contextlib2/__init__.py
+++ b/contextlib2/__init__.py
@@ -8,7 +8,7 @@ from collections import deque
 from functools import wraps
 from types import MethodType
 
-# Python 3.6/3.7/3.8 compatibility: GenericAlias may not be defined
+# Python 3.7/3.8 compatibility: GenericAlias may not be defined
 try:
     from types import GenericAlias
 except ImportError:
@@ -23,8 +23,6 @@ __all__ = ["asynccontextmanager", "contextmanager", "closing", "nullcontext",
            "AsyncExitStack", "ContextDecorator", "ExitStack",
            "redirect_stdout", "redirect_stderr", "suppress", "aclosing"]
 
-# Backwards compatibility
-__all__ += ["ContextStack"]
 
 class AbstractContextManager(abc.ABC):
     """An abstract base class for context managers."""

--- a/contextlib2/_typeshed.py
+++ b/contextlib2/_typeshed.py
@@ -1,5 +1,0 @@
-from typing import TypeVar  # pragma: no cover
-
-# Use for "self" annotations:
-#   def __enter__(self: Self) -> Self: ...
-Self = TypeVar("Self")  # pragma: no cover

--- a/dev/mypy.allowlist
+++ b/dev/mypy.allowlist
@@ -1,3 +1,10 @@
 # Deprecated APIs that never graduated to the standard library
 contextlib2.ContextDecorator.refresh_cm
-contextlib2.ContextStack
+
+# stubcheck no longer complains about this one for some reason
+# (but it does complain about the unused allowlist entry)
+# contextlib2.ContextStack
+
+# mypy seems to be confused by the GenericAlias compatibility hack
+contextlib2.AbstractAsyncContextManager.__class_getitem__
+contextlib2.AbstractContextManager.__class_getitem__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ PyPI page`_.
 There are no operating system or distribution specific versions of this
 module - it is a pure Python module that should work on all platforms.
 
-Supported Python versions are currently 3.7+.
+Supported Python versions are currently 3.8+.
 
 .. _Python Package Index: http://pypi.python.org
 .. _pip: http://www.pip-installer.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,7 +55,7 @@ PyPI page`_.
 There are no operating system or distribution specific versions of this
 module - it is a pure Python module that should work on all platforms.
 
-Supported Python versions are currently 3.6+.
+Supported Python versions are currently 3.7+.
 
 .. _Python Package Index: http://pypi.python.org
 .. _pip: http://www.pip-installer.org

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
-# No Python 3.6 available on current generation GitHub test runners
-envlist = py{37,38,39,3.10,3.11,3.12,py3}
+# Python 3.8 is the first version with positional-only argument syntax support
+envlist = py{38,39,3.10,3.11,3.12,py3}
 skip_missing_interpreters = True
 
 [testenv]
@@ -9,18 +9,16 @@ commands =
     coverage report
     coverage xml
     # mypy won't install on PyPy, so only run the typechecking on CPython
-    # Typechecking is currently failing: https://github.com/jazzband/contextlib2/issues/54
-    # !pypy3: python -m mypy.stubtest --allowlist dev/mypy.allowlist contextlib2
+    !pypy3: python -m mypy.stubtest --allowlist dev/mypy.allowlist contextlib2
 deps =
     coverage
     !pypy3: mypy
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
     3.10: py3.10
     3.11: py3.11
     3.12: py3.12
-    pypy-3.8: pypy3
+    pypy-3.10: pypy3


### PR DESCRIPTION
* sync with latest typeshed stub file (closes #54)
* publish `dev/mypy.allowlist` in sdist (closes #53)
* drop Python 3.7 support due to positional-only arg syntax in the updated stub file